### PR TITLE
新增迁移json类型字段支持

### DIFF
--- a/src/DDLSyntax/DDLColumnSyntax.php
+++ b/src/DDLSyntax/DDLColumnSyntax.php
@@ -58,6 +58,10 @@ class DDLColumnSyntax
         DataType::LONGBLOB,
     ];
 
+    private static $json = [
+        DataType::JSON
+    ];
+
     /**
      * @param string $tableSchema
      * @param string $tableName
@@ -124,6 +128,8 @@ class DDLColumnSyntax
         } elseif (in_array($colAttrs['DATA_TYPE'], self::$text)) {
             $ddlSyntax = "\$table->{$colAttrs['DATA_TYPE']}('{$colAttrs['COLUMN_NAME']}')";
         } elseif (in_array($colAttrs['DATA_TYPE'], self::$blob)) {
+            $ddlSyntax = "\$table->{$colAttrs['DATA_TYPE']}('{$colAttrs['COLUMN_NAME']}')";
+        } elseif (in_array($colAttrs['DATA_TYPE'], self::$json)) {
             $ddlSyntax = "\$table->{$colAttrs['DATA_TYPE']}('{$colAttrs['COLUMN_NAME']}')";
         } else {
             return sprintf('// Todo::For some reason the field "%s" is not generated', $colAttrs['COLUMN_NAME']);

--- a/tests/MigrateCommandTest.php
+++ b/tests/MigrateCommandTest.php
@@ -80,6 +80,7 @@ class MigrateCommandTest extends TestCase
                 CREATE TABLE IF NOT EXISTS `{$tableName}` (
                   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
                   `name` varchar(255) DEFAULT NULL,
+                  `info` JSON DEFAULT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci";
                 MigrateManager::getInstance()->query($createSql);


### PR DESCRIPTION
由于数据库迁移文件依赖easyswoole/ddl 进行迁移，所以还需要配合easyswoole/ddl的pr提交使用。否则也是不生效的。